### PR TITLE
Move scrape discovery to files in targets/ dir (so agent can dynamically scrape targets when more exporters are installed on system)

### DIFF
--- a/agents/host-amd64/agent-config.yaml
+++ b/agents/host-amd64/agent-config.yaml
@@ -9,9 +9,10 @@ prometheus:
   configs:
     - name: default
       scrape_configs:
-        - job_name: integrations/node-exporter
-          static_configs:
-          - targets: ['localhost:9100']
+        - job_name: file-sd-targets
+          file_sd_configs:
+          - files:
+            - '/etc/opsverse/targets/*.json'
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'

--- a/agents/host-amd64/setup.sh
+++ b/agents/host-amd64/setup.sh
@@ -40,7 +40,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Show help, if necessary, and exit
-if [ "$HELP" = true ] || [ -z $METRICS_HOST ] || [ -z $LOGS_HOST ] || [ -z $TRACES_HOST ] || [ -z $PASS ] ; then
+if [ "$HELP" = true ] || [ -z $METRICS_HOST ] || [ -z $LOGS_HOST ] || [ -z $PASS ] ; then
   echo "Installs the OpsVerse Agent on your machine"
   echo ""
   echo "Usage: sudo installer -- [OPTIONS]" 
@@ -48,7 +48,7 @@ if [ "$HELP" = true ] || [ -z $METRICS_HOST ] || [ -z $LOGS_HOST ] || [ -z $TRAC
   echo "Arguments:"
   echo "  -m, --metrics-host             Your Prometheus-compatible metrics host"
   echo "  -l, --logs-host                Your Loki host"
-  echo "  -t, --traces-collector-host    Your traces collector host"
+  echo "  -t, --traces-collector-host    Your traces collector host (optional)"
   echo "  -p, --password                 Your ObserveNow instance auth password"
   echo ""
   echo "Example:"
@@ -62,10 +62,11 @@ fi
 
 
 # move executable and config to appropriate directories
-mkdir -p /usr/local/bin/ /etc/opsverse
+mkdir -p /usr/local/bin/ /etc/opsverse/targets
 cp -f ./agent-v0.13.1-linux-amd64 /usr/local/bin/opsverse-telemetry-agent
 cp -f ./node_exporter /usr/local/bin/node_exporter
 cp -f ./agent-config.yaml /etc/opsverse/
+cp -f ./targets-node-exporter.json /etc/opsverse/targets/node-exporter.json
 chmod +x /usr/local/bin/opsverse-telemetry-agent
 chmod +x /usr/local/bin/node_exporter
 
@@ -78,22 +79,24 @@ sed -i "s/__TRACES_HOST__/${TRACES_COLLECTOR_HOST}/g" /etc/opsverse/agent-config
 sed -i "s/__PASSWORD__/${PASS}/g" /etc/opsverse/agent-config.yaml
 sed -i "s/__HOST__/${HOSTNAME}/g" /etc/opsverse/agent-config.yaml
 
-# Setup the SystemD service file
+# Setup the systemd service file
 if [ -f ${SERVICE_FILE} ]; then
   systemctl stop ${SERVICE_NAME}.service
   systemctl disable ${SERVICE_NAME}.service
-  cp -f ./${SERVICE_NAME}.service ${SERVICE_FILE}
-else
-  cp -f ./${SERVICE_NAME}.service ${SERVICE_FILE}
+
+  echo "Backing up existing service (${SERVICE_FILE} file to /tmp"
+  cp -f ${SERVICE_FILE} /tmp
 fi
+cp -f ./${SERVICE_NAME}.service ${SERVICE_FILE}
 
 if [ -f ${NODE_EXPORTER_SERVICE_FILE} ]; then
   systemctl stop ${NODE_EXPORTER_SERVICE_NAME}.service
   systemctl disable ${NODE_EXPORTER_SERVICE_NAME}.service
-  cp -f ./${NODE_EXPORTER_SERVICE_NAME}.service ${NODE_EXPORTER_SERVICE_FILE}
-else
-  cp -f ./${NODE_EXPORTER_SERVICE_NAME}.service ${NODE_EXPORTER_SERVICE_FILE}
+
+  echo "Backing up existing service (${NODE_EXPORTER_SERVICE_FILE} file to /tmp"
+  cp -f ${NODE_EXPORTER_SERVICE_FILE} /tmp
 fi
+cp -f ./${NODE_EXPORTER_SERVICE_NAME}.service ${NODE_EXPORTER_SERVICE_FILE}
 
 # opsverse-agent service
 systemctl enable ${SERVICE_NAME}.service

--- a/agents/host-amd64/targets-node-exporter.json
+++ b/agents/host-amd64/targets-node-exporter.json
@@ -1,0 +1,10 @@
+[
+  {
+    "labels": {
+      "job": "integrations/node-exporter"
+    },
+    "targets": [
+      "localhost:9100"
+    ]
+  }
+]


### PR DESCRIPTION
@arul-opsverse , this is to prep for additional exporters on a single machine.

## Summary

Moved scrape config for node-exporter to file-based service discovery (`/etc/opsverse/targets/node-exporter.json`)

This will allow users (or us) to simply drop a new target json into  `/etc/opsverse/targets/` when additional exporters are installed - for the agent to dynamically pick up and scrape

## Testing

Created `./installer.sh` and installed on my Ubuntu VM - verified metrics coming in.