### PR TITLE
SysV log redirect and chkconfig on for exporters

### DIFF
--- a/agents/host-amd64/node_exporter.sysv
+++ b/agents/host-amd64/node_exporter.sysv
@@ -29,7 +29,7 @@ usage ()
 start ()
 {
 	echo $"Starting node_exporter" 1>&2
-    /usr/local/bin/node_exporter &	
+	/usr/local/bin/node_exporter >> /var/log/node_exporter.log 2>&1 &
 	touch /var/lock/subsys/node_exporter
 	success $"node_exporter startup"
 	echo

--- a/agents/host-amd64/opsverse-agent.sysv
+++ b/agents/host-amd64/opsverse-agent.sysv
@@ -30,7 +30,7 @@ usage ()
 start ()
 {
 	echo $"Starting opsverse-agent" 1>&2
-	/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml &
+	/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml >> /var/log/opsverse-telemetry-agent.log 2>&1 &
 	touch /var/lock/subsys/opsverse-agent
 	success $"opsverse-agent startup"
 	echo


### PR DESCRIPTION
## Summary of Changes

- Redirect sysv init script logs to /var/log/ (logs to stdout confusing users as a "running" process"
-  Add `chkconfig on` for exporters too
- Cleaner `killproc` of processes for `stop`

## Testing

Tested by installing exporter from this branch:

```
$ curl https://raw.githubusercontent.com/OpsVerseIO/installers/sysv-tweaks/prometheus-exporters/install-exporter-amd64.sh | sudo bash -s -- -e mysqld 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10034  100 10034    0     0  26062      0 --:--:-- --:--:-- --:--:-- 26062
--2022-06-01 00:55:52--  https://github.com/prometheus/mysqld_exporter/releases/download/v0.14.0/mysqld_exporter-0.14.0.linux-amd64.tar.gz
Resolving github.com (github.com)... 13.234.176.102
Connecting to github.com (github.com)|13.234.176.102|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/32075541/32c409af-b7bf-4f96-a811-72cf640f4ee4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220601%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220601T005553Z&X-Amz-Expires=300&X-Amz-Signature=be48e63632e6ecf8dbbcd1c48685e5dd47e03891105d9c8979dd917ea74a0603&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32075541&response-content-disposition=attachment%3B%20filename%3Dmysqld_exporter-0.14.0.linux-amd64.tar.gz&response-content-type=application%2Foctet-stream [following]
--2022-06-01 00:55:53--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/32075541/32c409af-b7bf-4f96-a811-72cf640f4ee4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220601%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220601T005553Z&X-Amz-Expires=300&X-Amz-Signature=be48e63632e6ecf8dbbcd1c48685e5dd47e03891105d9c8979dd917ea74a0603&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32075541&response-content-disposition=attachment%3B%20filename%3Dmysqld_exporter-0.14.0.linux-amd64.tar.gz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7450991 (7.1M) [application/octet-stream]
Saving to: ‘mysqld_exporter-0.14.0.linux-amd64.tar.gz’

mysqld_exporter-0.14.0.linux-amd64.tar.gz    100%[==============================================================================================>]   7.11M  8.89MB/s    in 0.8s    

2022-06-01 00:55:55 (8.89 MB/s) - ‘mysqld_exporter-0.14.0.linux-amd64.tar.gz’ saved [7450991/7450991]

systemd not found on system... falling back to SysV
Stopping prom-mysqld-exporter
[FAILED]
Backing up existing service /etc/init.d/prom-mysqld-exporter file to /tmp
Starting prom-mysqld-exporter
[  OK  ]
```

After updating `/etc/opsverse/exporters/mysqld/.my.cnf` with a public instance, restarted the exporter and looked at logs:

```
$ service prom-mysqld-exporter restart
Stopping prom-mysqld-exporter
                                                           [  OK  ]
Starting prom-mysqld-exporter
                                                           [  OK  ]
                                                           
$ tail -f /var/log/prom-mysqld-exporter.log 
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:277 level=info msg="Starting mysqld_exporter" version="(version=0.14.0, branch=HEAD, revision=ca1b9af82a471c849c529eb8aadb1aac73e7b68c)"
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:278 level=info msg="Build context" (gogo1.17.8,userroot@401d370ca42e,date20220304-16:25:15)=(MISSING)
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=global_status
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=global_variables
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=slave_status
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=info_schema.innodb_cmp
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=info_schema.innodb_cmpmem
ts=2022-06-01T00:59:50.396Z caller=mysqld_exporter.go:293 level=info msg="Scraper enabled" scraper=info_schema.query_response_time
ts=2022-06-01T00:59:50.397Z caller=mysqld_exporter.go:303 level=info msg="Listening on address" address=:9104
ts=2022-06-01T00:59:50.397Z caller=tls_config.go:195 level=info msg="TLS is disabled." http2=false
ts=2022-06-01T01:00:19.141Z caller=exporter.go:149 level=error msg="Error pinging mysqld" err="Error 1045: Access denied for user 'rfamro'@'ec2-13-126-144-124.ap-south-1.compute.amazonaws.com' (using password: YES)"
ts=2022-06-01T01:00:48.688Z caller=exporter.go:149 level=error msg="Error pinging mysqld" err="Error 1045: Access denied for user 'rfamro'@'ec2-13-126-144-124.ap-south-1.compute.amazonaws.com' (using password: YES)
```

For the installer, we regenerated it and placed it in the S3 bucket (with public read permissions)