### PR TITLE
Handle run pids for sysv systems

### DIFF
--- a/agents/host-amd64/node_exporter.sysv
+++ b/agents/host-amd64/node_exporter.sysv
@@ -31,6 +31,7 @@ start ()
 	echo $"Starting node_exporter" 1>&2
 	/usr/local/bin/node_exporter >> /var/log/node_exporter.log 2>&1 &
 	touch /var/lock/subsys/node_exporter
+	touch $(pidof node_exporter) > /var/run/node_exporter.pid
 	success $"node_exporter startup"
 	echo
 }
@@ -41,6 +42,7 @@ stop ()
 	echo $"Stopping node_exporter" 1>&2
 	killproc node_exporter
 	rm -f /var/lock/subsys/node_exporter
+	rm -f /var/run/node_exporter.pid
 	echo
 }
 

--- a/agents/host-amd64/opsverse-agent.sysv
+++ b/agents/host-amd64/opsverse-agent.sysv
@@ -32,6 +32,7 @@ start ()
 	echo $"Starting opsverse-agent" 1>&2
 	/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml >> /var/log/opsverse-telemetry-agent.log 2>&1 &
 	touch /var/lock/subsys/opsverse-agent
+	echo $(pidof opsverse-telemetry-agent) > /var/run/opsverse-agent.pid
 	success $"opsverse-agent startup"
 	echo
 }
@@ -42,6 +43,7 @@ stop ()
 	echo $"Stopping opsverse-agent" 1>&2
 	killproc opsverse-telemetry-agent
 	rm -f /var/lock/subsys/opsverse-agent
+	rm -f /var/run/opsverse-agent.pid
 	echo
 }
 

--- a/fixit-scripts/patch-sysv-runpid.sh
+++ b/fixit-scripts/patch-sysv-runpid.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+for file_to_patch in /etc/init.d/opsverse* /etc/init.d/node_export* /etc/init.d/prom-*; do
+  if grep -q pidof $file_to_patch; then
+    echo "$file_to_patch already contains patch"
+  else
+    if grep -q opsverse $file_to_patch; then
+      echo "patching $file_to_patch..."
+      initscript=$(grep touch $file_to_patch | awk '{print $2}' | xargs basename)
+      procname=$(grep killproc $file_to_patch | awk '{print $2}')
+
+      sed -E -i "s/(\ttouch.*)/\1\n\techo \$(pidof ${procname}) > \/var\/run\/${initscript}.pid/" $file_to_patch
+      sed -E -i "s/(\trm -f \/var\/lock.*)/\1\n\trm -f \/var\/run\/${initscript}.pid/" $file_to_patch
+      echo "done."
+    fi
+  fi
+done

--- a/prometheus-exporters/install-exporter-amd64.sh
+++ b/prometheus-exporters/install-exporter-amd64.sh
@@ -284,6 +284,8 @@ start ()
 	echo $"Starting $EXPORTER_SERVICE_NAME" 1>&2
 	$EXPORTER_COMMAND >> ${EXPORTER_LOG} 2>&1  &
 	touch /var/lock/subsys/$EXPORTER_SERVICE_NAME
+	echo \$(pidof $EXPORTER_KILLPROC) > /var/run/${EXPORTER_SERVICE_NAME}.pid
+
 	success $"$EXPORTER_SERVICE_NAME startup"
 	echo
 }
@@ -294,6 +296,7 @@ stop ()
 	echo $"Stopping $EXPORTER_SERVICE_NAME" 1>&2
 	killproc $EXPORTER_KILLPROC
 	rm -f /var/lock/subsys/$EXPORTER_SERVICE_NAME
+	rm -f /var/run/${EXPORTER_SERVICE_NAME}.pid
 	echo
 }
 


### PR DESCRIPTION
## Why

Sysv customers reporting `opsverse-agent dead but subsys locked`

## Root Cause

`.run` and pid lock mismatch. We're now takin `pidof` to write the runpid

## Testing

We have a patch script that fixes already installed init scripts (so no need to re-install, which will squash configs). Tested on a running system with this branch:

```
$ curl https://raw.githubusercontent.com/OpsVerseIO/installers/bugfix/sysv-runpid/fixit-scripts/patch-sysv-runpid.sh | sudo bash -s
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   685  100   685    0     0   1991      0 --:--:-- --:--:-- --:--:--  1991
/etc/init.d/opsverse-agent already contains patch
patching /etc/init.d/prom-mongodb-exporter...
done.
patching /etc/init.d/prom-mysqld-exporter...
done.
$ sudo service prom-mysqld-exporter status
prom-mysqld-exporter dead but subsys locked
$ sudo service prom-mysqld-exporter restart
Stopping prom-mysqld-exporter
                                                           [  OK  ]
Starting prom-mysqld-exporter
                                                           [  OK  ]
$ sudo service prom-mysqld-exporter status
prom-mysqld-exporter (pid  4041) is running...
```

