### PR TITLE
Add env-expansion option to grafana agent and options to force or skip agent config overrides

### DIFF
--- a/agents/host-amd64/opsverse-agent.service
+++ b/agents/host-amd64/opsverse-agent.service
@@ -3,7 +3,7 @@ Description=OpsVerse Agent
 
 [Service]
 User=root
-ExecStart=/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml
+ExecStart=/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml -config.expand-env
 Restart=always
 
 [Install]

--- a/agents/host-amd64/opsverse-agent.sysv
+++ b/agents/host-amd64/opsverse-agent.sysv
@@ -30,7 +30,7 @@ usage ()
 start ()
 {
 	echo $"Starting opsverse-agent" 1>&2
-	/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml >> /var/log/opsverse-telemetry-agent.log 2>&1 &
+	/usr/local/bin/opsverse-telemetry-agent --config.file=/etc/opsverse/agent-config.yaml -config.expand-env >> /var/log/opsverse-telemetry-agent.log 2>&1 &
 	touch /var/lock/subsys/opsverse-agent
 	echo $(pidof opsverse-telemetry-agent) > /var/run/opsverse-agent.pid
 	success $"opsverse-agent startup"


### PR DESCRIPTION
@arul-opsverse , adding the following info section in docs to detail its usage:

![Mon 27 Jun 2022 04-56-16 PM PDT](https://user-images.githubusercontent.com/88401519/176058764-8fb5b024-0c8a-4381-8660-b92da08b5217.png)

We're also now passing in `-config.expand-env` to the grafana-agent startup in case customers push out their own agent configs which have environment variable references that need interpolation.

## Testing

On test instance with already existing installation:
```
$ sudo ./installer.sh -- -m <redacted> -l <redacted> -p <redacted>
Verifying archive integrity...  100%   All good.
Uncompressing OpsVerse Agent Installer  100%  
An agent config at /etc/opsverse/agent-config.yaml already exists...

There is already an existing agent config at /etc/opsverse/agent-config.yaml.
Please select one of the following options:
 (o) - to (o)verride it with the defaults
 (e) - to use the (e)xisting config
 (v) - to (v)iew the diff
Enter option: 
``` 

Passing ` --no-config-override` to not prompt and use existing:
```
$ sudo ./installer.sh -- -m <redacted> -l <redacted> -p <redacted> --no-config-override
Verifying archive integrity...  100%   All good.
Uncompressing OpsVerse Agent Installer  100%  
An agent config at /etc/opsverse/agent-config.yaml already exists...
--no-config-override option passed, so we'll use the existing /etc/opsverse/agent-config.yaml ...
Removed /etc/systemd/system/multi-user.target.wants/opsverse-agent.service.
Backing up existing service (/etc/systemd/system/opsverse-agent.service) file to /tmp
Removed /etc/systemd/system/multi-user.target.wants/node_exporter.service.
Backing up existing service (/etc/systemd/system/node_exporter.service) file to /tmp
Created symlink /etc/systemd/system/multi-user.target.wants/opsverse-agent.service → /etc/systemd/system/opsverse-agent.service.
Created symlink /etc/systemd/system/multi-user.target.wants/node_exporter.service → /etc/systemd/system/node_exporter.service.
```

Passing `-f` to not prompt and force override:
```
$ sudo ./installer.sh -- -m <redacted> -l <redacted> -p <redacted>  -f
Verifying archive integrity...  100%   All good.
Uncompressing OpsVerse Agent Installer  100%  
An agent config at /etc/opsverse/agent-config.yaml already exists...
--force-config-override option passed, so we'll use  a default agent config file...
Removed /etc/systemd/system/multi-user.target.wants/opsverse-agent.service.
Backing up existing service (/etc/systemd/system/opsverse-agent.service) file to /tmp
Removed /etc/systemd/system/multi-user.target.wants/node_exporter.service.
Backing up existing service (/etc/systemd/system/node_exporter.service) file to /tmp
Created symlink /etc/systemd/system/multi-user.target.wants/opsverse-agent.service → /etc/systemd/system/opsverse-agent.service.
```