### PR TITLE
Move required dirs creation before the config check reconciliaiton

### DIFF
--- a/agents/host-amd64/setup.sh
+++ b/agents/host-amd64/setup.sh
@@ -115,6 +115,9 @@ function install_agent_config () {
   sed -i "s/__HOST__/${HOSTNAME}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
 }
 
+# Ensure target dirs are created
+mkdir -p /usr/local/bin/ /etc/opsverse/targets
+
 if [ -f ${OPSVERSE_AGENT_CONFIG_FULLPATH} ] ; then
 
   echo "An agent config at ${OPSVERSE_AGENT_CONFIG_FULLPATH} already exists..."
@@ -160,7 +163,6 @@ else
 fi
 
 # move executable and config to appropriate directories
-mkdir -p /usr/local/bin/ /etc/opsverse/targets
 cp -f ./agent-v0.13.1-linux-amd64 /usr/local/bin/opsverse-telemetry-agent
 cp -f ./node_exporter /usr/local/bin/node_exporter
 cp -f ./targets-node-exporter.json ${ETC_OPSVERSE}/targets/node-exporter.json


### PR DESCRIPTION
## Why

Since we added the config check reconciliation, it moves files to directories that may not exist in new installations.

So moving it up!

## Test Results

N/A; I am 100% confident this is the cause.

## Reviewer Consideration

installer.sh created and uploaded to S3 (w/ permission change)