### PR TITLE
[Installers] Changed grafana agent version to latest and made some changes required to run the latest version

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -3,5 +3,5 @@ OPSVERSE_METRICS_ENDPOINT=https://<observeNowMetricsHost>/api/v1/write
 OPSVERSE_LOGS_ENDPOINT=https://<observeNowLogsHost>/loki/api/v1/push
 OPSVERSE_USERNAME=devopsnow
 OPSVERSE_PASSWORD=<observeNowPassword>
-AGENT_VERSION=latest
+AGENT_VERSION=v0.28.0
 SCRAPE_INTERVAL=30s

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -3,5 +3,5 @@ OPSVERSE_METRICS_ENDPOINT=https://<observeNowMetricsHost>/api/v1/write
 OPSVERSE_LOGS_ENDPOINT=https://<observeNowLogsHost>/loki/api/v1/push
 OPSVERSE_USERNAME=devopsnow
 OPSVERSE_PASSWORD=<observeNowPassword>
-AGENT_VERSION=v0.13.1
+AGENT_VERSION=latest
 SCRAPE_INTERVAL=30s

--- a/docker-compose/agent.yaml
+++ b/docker-compose/agent.yaml
@@ -44,20 +44,6 @@ logs:
         - action: labelmap
           regex: __meta_docker_(.+)
           replacement: $1
-    - job_name: var-log
-      static_configs:
-        - labels:
-            job: varlog
-            host: ${HOST}
-            __path__: /var/log/*.log
-    - job_name: containers
-      static_configs:
-        - targets:
-            - localhost
-          labels:
-            job: containerlogs
-            host: ${HOST}
-            __path__: /var/lib/docker/containers/*/*log
     clients:
       - url: ${OPSVERSE_LOGS_ENDPOINT}
         basic_auth:

--- a/docker-compose/agent.yaml
+++ b/docker-compose/agent.yaml
@@ -40,9 +40,6 @@ logs:
       docker_sd_configs:
         - host: unix:///var/run/docker.sock
           refresh_interval: 5s
-          filters:
-            - name: name
-              values: ['devopsnow-agent']
       relabel_configs:
         - action: labelmap
           regex: __meta_docker_(.+)

--- a/docker-compose/agent.yaml
+++ b/docker-compose/agent.yaml
@@ -1,10 +1,14 @@
 server:
-  # log_level: debug
-  http_listen_port: 12345
+  log_level: info
 
-prometheus:
+metrics:
   global:
     scrape_interval: ${SCRAPE_INTERVAL}
+    remote_write:
+      - url: ${OPSVERSE_METRICS_ENDPOINT}
+        basic_auth:
+          username: ${OPSVERSE_USERNAME}
+          password: ${OPSVERSE_PASSWORD}
   configs:
     - name: default
       scrape_configs:
@@ -25,36 +29,40 @@ prometheus:
               regex: '.*'
               target_label: instance
               replacement: ${HOST}
-      remote_write:
-        - url: ${OPSVERSE_METRICS_ENDPOINT}
-          basic_auth:
-            username: ${OPSVERSE_USERNAME}
-            password: ${OPSVERSE_PASSWORD}
-loki:
-  positions_directory: /tmp/
-  configs:
-    - name: local
-      clients:
-        - url: ${OPSVERSE_LOGS_ENDPOINT}
-          basic_auth:
-            username: ${OPSVERSE_USERNAME}
-            password: ${OPSVERSE_PASSWORD}
-      scrape_configs:
-        # Add a job for any new dir that needs to be tailed for logs
-        - job_name: var-log
-          static_configs:
-            - labels:
-                job: varlog
-                host: ${HOST}
-                __path__: /var/log/*.log
-        - job_name: containers
-          static_configs:
-          - targets:
-              - localhost
-            labels:
-              job: containerlogs
-              host: ${HOST}
-              __path__: /var/lib/docker/containers/*/*log
 
-          pipeline_stages:
-            - docker: {}
+logs:
+  configs:
+  - name: default
+    positions:
+      filename: /tmp/positions.yaml
+    scrape_configs:
+    - job_name: "docker_scrape"
+      docker_sd_configs:
+        - host: unix:///var/run/docker.sock
+          refresh_interval: 5s
+          filters:
+            - name: name
+              values: ['devopsnow-agent']
+      relabel_configs:
+        - action: labelmap
+          regex: __meta_docker_(.+)
+          replacement: $1
+    - job_name: var-log
+      static_configs:
+        - labels:
+            job: varlog
+            host: ${HOST}
+            __path__: /var/log/*.log
+    - job_name: containers
+      static_configs:
+        - targets:
+            - localhost
+          labels:
+            job: containerlogs
+            host: ${HOST}
+            __path__: /var/lib/docker/containers/*/*log
+    clients:
+      - url: ${OPSVERSE_LOGS_ENDPOINT}
+        basic_auth:
+          username: ${OPSVERSE_USERNAME}
+          password: ${OPSVERSE_PASSWORD}

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -9,10 +9,11 @@ services:
       - ./agent/config:/etc/agent-config
       - /var/log:/var/log
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     entrypoint:
       - /bin/agent
       - -config.file=/etc/agent-config/agent.yaml
-      - -prometheus.wal-directory=/tmp/agent/wal
+      - -metrics.wal-directory=/tmp/agent/wal
       - -config.expand-env
     ports:
       - "12345:12345"
@@ -42,7 +43,7 @@ services:
       - 9100
     labels:
       org.label-schema.group: "monitoring"
-
+ 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
     container_name: cadvisor


### PR DESCRIPTION
Tested this using a GCP VM (`aditya-test-instance`)
Results: Got all the docker metadata labels in Loki
<img width="1272" alt="Screenshot 2022-10-18 at 13 21 48" src="https://user-images.githubusercontent.com/99061867/196389462-a48cc47c-af13-48c7-b69f-fb542ee22a69.png">
