### PR TITLE
Add terraform for EKS cluster creation 

### DIFF
--- a/misc/terraform/aws/eks/README.md
+++ b/misc/terraform/aws/eks/README.md
@@ -1,0 +1,18 @@
+# EKS
+
+Create an EKS cluster
+
+If you don't have Terraform already installed on your system, you may [download from here](https://www.terraform.io/downloads)
+
+## Steps
+
+While in this directory...
+
+1. Edit `vars.tfvars` to update the values based on your network/environment (make sure worker node subnets in `eks.tf` refer to only the private subnets)
+
+2. Run `terraform init -var-file=vars.tfvars` 
+
+3. Run `terraform plan -var-file=vars.tfvars` and review the plan
+
+4. Run `terraform apply -var-file=vars.tfvars` to actually apply
+

--- a/misc/terraform/aws/eks/eks.tf
+++ b/misc/terraform/aws/eks/eks.tf
@@ -1,0 +1,39 @@
+# Creates a 3-node EKS cluster. You may additionally want to:
+#   - add more subnets to span whichever networks you want
+#   - add manage_aws_auth="true" in case you do auth maps here too 
+#   - change cluster/module name to one that fits your org conventions
+
+module "opsverse-eks-cluster" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.1.0"
+
+  cluster_name    = "opsverse-eks-cluster"
+  cluster_version = "1.21"
+  # manage_aws_auth= "true"
+
+  // Need at least 2 AZs for EKS to create cluster
+  subnets         = [
+                    "${var.subnet_ids[0]}",
+                    "${var.subnet_ids[1]}",
+                    "${var.subnet_ids[2]}",
+                    "${var.subnet_ids[3]}"
+                    ]
+  vpc_id          = "${var.vpc_id}"
+  enable_irsa     = "true" 
+
+  worker_groups = [
+    {
+      instance_type = "m5a.xlarge"
+      asg_max_size = 3
+      asg_desired_capacity = 3
+      asg_min_size = 3
+      root_volume_size = "30"
+      root_volume_type = "gp2"
+      key_name = var.keypair_name
+      subnets = [
+        "${var.subnet_ids[0]}",
+        "${var.subnet_ids[2]}"
+      ]
+    }
+  ]
+}

--- a/misc/terraform/aws/eks/iam.tf
+++ b/misc/terraform/aws/eks/iam.tf
@@ -1,0 +1,84 @@
+# Creates a role for the Loki pods to access the pre-created S3 bucket
+# for Loki backend.
+#
+# Assumption, the bucket var.s3_bucket is already created in same region 
+#
+# Note: if you changed module name in eks.tf from "opsverse-eks-cluster", please
+#       update this script to replace "opsverse-eks-cluster".
+
+resource "aws_iam_role" "iam_for_loki_pods" {
+  name = "eks-opsverse-s3-pod-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${module.opsverse-eks-cluster.oidc_provider_arn}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition":  {
+        "StringLike": {
+          "${replace(module.opsverse-eks-cluster.oidc_provider_arn, "${element(split("/", module.opsverse-eks-cluster.oidc_provider_arn), 0)}/", "")}:sub": "system:serviceaccount:*:${var.s3_bucket}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "loki_pod_permissions" {
+  name   = "opsverse-eks-pod-permissions"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${var.s3_bucket}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${var.s3_bucket}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "tag:GetResources",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF 
+}
+
+resource "aws_iam_role_policy_attachment" "loki_pod_permissions" {
+  role       = aws_iam_role.iam_for_loki_pods.name
+  policy_arn = aws_iam_policy.loki_pod_permissions.arn
+}
+
+output "loki_pod_role_arn" {
+  value = aws_iam_role.iam_for_loki_pods.arn 
+}

--- a/misc/terraform/aws/eks/provider.tf
+++ b/misc/terraform/aws/eks/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 3.0"  
+    }
+  }
+}
+
+

--- a/misc/terraform/aws/eks/s3.tf
+++ b/misc/terraform/aws/eks/s3.tf
@@ -1,0 +1,14 @@
+##############
+# Loki storage buckets
+##############
+
+module "s3_bucket_opsverse" {
+  source = "../modules/s3"
+
+  bucket_name = var.s3_bucket 
+  bucket_tags = {
+    Name        = var.s3_bucket
+    Environment = "production"
+  }
+}
+

--- a/misc/terraform/aws/eks/variables.tf
+++ b/misc/terraform/aws/eks/variables.tf
@@ -1,0 +1,8 @@
+## Fill in with your network configs
+variable "aws_region" {}
+variable "keypair_name" {}
+variable "s3_bucket" { }
+variable "subnet_ids" { type = list }
+variable "vpc_id" {}
+variable "aws_profile" {}
+

--- a/misc/terraform/aws/eks/vars.tfvars
+++ b/misc/terraform/aws/eks/vars.tfvars
@@ -1,0 +1,11 @@
+aws_profile = "default"
+aws_region = "us-west-2"
+s3_bucket = "opsverse-loki-yourname-stackname"
+subnet_ids = [
+    "subnet-123456", 
+    "subnet-234567", 
+    "subnet-345678", 
+    "subnet-456789" 
+]
+vpc_id = "vpc-123456"
+keypair_name = "bastion"

--- a/misc/terraform/aws/modules/s3/main.tf
+++ b/misc/terraform/aws/modules/s3/main.tf
@@ -1,0 +1,18 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.bucket_name 
+  tags = merge(var.bucket_tags)
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = var.public_access ? "public-read" : "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access_policy" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls         = var.public_access ? false: true
+  block_public_policy       = var.public_access ? false: true
+  ignore_public_acls        = var.public_access ? false: true
+  restrict_public_buckets   = var.public_access ? false: true
+}

--- a/misc/terraform/aws/modules/s3/variables.tf
+++ b/misc/terraform/aws/modules/s3/variables.tf
@@ -1,0 +1,8 @@
+variable "bucket_name" {}
+variable "bucket_tags" {
+  type    = map(string)
+  default = {}
+}
+variable "public_access" {
+  default = false
+}


### PR DESCRIPTION
Tested with a `plan`:

```
$ terraform_v1.3.4 plan -var-file=vars.tfvars
provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Enter a value: us-west-2

module.opsverse-eks-cluster.data.aws_partition.current: Reading...
module.opsverse-eks-cluster.data.aws_caller_identity.current: Reading...
module.opsverse-eks-cluster.data.aws_partition.current: Read complete after 0s [id=aws]
module.opsverse-eks-cluster.data.aws_ami.eks_worker[0]: Reading...
module.opsverse-eks-cluster.data.aws_iam_policy_document.workers_assume_role_policy: Reading...
module.opsverse-eks-cluster.data.aws_iam_policy_document.cluster_assume_role_policy: Reading...
module.opsverse-eks-cluster.data.aws_iam_policy_document.cluster_elb_sl_role_creation[0]: Reading...
module.opsverse-eks-cluster.data.aws_iam_policy_document.cluster_elb_sl_role_creation[0]: Read complete after 0s [id=3709839417]
module.opsverse-eks-cluster.data.aws_iam_policy_document.workers_assume_role_policy: Read complete after 0s [id=3778018924]
module.opsverse-eks-cluster.data.aws_iam_policy_document.cluster_assume_role_policy: Read complete after 0s [id=2764486067]
module.opsverse-eks-cluster.data.aws_caller_identity.current: Read complete after 0s [id=267336882952]
module.opsverse-eks-cluster.data.aws_ami.eks_worker[0]: Read complete after 0s [id=ami-0ca2b190717f1671e]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # aws_iam_policy.loki_pod_permissions will be created
  + resource "aws_iam_policy" "loki_pod_permissions" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "opsverse-eks-pod-permissions"
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:GetObject",
                          + "s3:PutObject",
                          + "s3:DeleteObject",
                          + "s3:ListBucket",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::opsverse-loki-yourname-stackname/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "s3:ListBucket",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::opsverse-loki-yourname-stackname",
                        ]
                    },
                  + {
                      + Action   = [
                          + "tag:GetResources",
                          + "cloudwatch:GetMetricData",
                          + "cloudwatch:GetMetricStatistics",
                          + "cloudwatch:ListMetrics",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "*",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = (known after apply)
    }

  # aws_iam_role.iam_for_loki_pods will be created
  + resource "aws_iam_role" "iam_for_loki_pods" {
      + arn                   = (known after apply)
      + assume_role_policy    = (known after apply)
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eks-opsverse-s3-pod-role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_iam_role_policy_attachment.loki_pod_permissions will be created
  + resource "aws_iam_role_policy_attachment" "loki_pod_permissions" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "eks-opsverse-s3-pod-role"
    }

  # module.opsverse-eks-cluster.data.http.wait_for_cluster[0] will be read during apply
  # (config refers to values not yet known)
 <= data "http" "wait_for_cluster" {
      + body             = (known after apply)
      + ca_certificate   = (known after apply)
      + id               = (known after apply)
      + response_headers = (known after apply)
      + timeout          = 300
      + url              = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_autoscaling_group.workers[0] will be created
  + resource "aws_autoscaling_group" "workers" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + capacity_rebalance        = false
      + default_cooldown          = (known after apply)
      + desired_capacity          = 3
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = (known after apply)
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_instance_lifetime     = 0
      + max_size                  = 3
      + metrics_granularity       = "1Minute"
      + min_size                  = 3
      + name                      = (known after apply)
      + name_prefix               = "opsverse-eks-cluster-0"
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + suspended_processes       = [
          + "AZRebalance",
        ]
      + termination_policies      = []
      + vpc_zone_identifier       = [
          + "subnet-123456",
          + "subnet-234567",
        ]
      + wait_for_capacity_timeout = "10m"

      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "opsverse-eks-cluster-0-eks_asg"
        }
      + tag {
          + key                 = "k8s.io/cluster/opsverse-eks-cluster"
          + propagate_at_launch = true
          + value               = "owned"
        }
      + tag {
          + key                 = "kubernetes.io/cluster/opsverse-eks-cluster"
          + propagate_at_launch = true
          + value               = "owned"
        }
    }

  # module.opsverse-eks-cluster.aws_eks_cluster.this[0] will be created
  + resource "aws_eks_cluster" "this" {
      + arn                   = (known after apply)
      + certificate_authority = (known after apply)
      + created_at            = (known after apply)
      + endpoint              = (known after apply)
      + id                    = (known after apply)
      + identity              = (known after apply)
      + name                  = "opsverse-eks-cluster"
      + platform_version      = (known after apply)
      + role_arn              = (known after apply)
      + status                = (known after apply)
      + tags_all              = (known after apply)
      + version               = "1.21"

      + kubernetes_network_config {
          + ip_family         = (known after apply)
          + service_ipv4_cidr = (known after apply)
        }

      + timeouts {
          + create = "30m"
          + delete = "15m"
        }

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = false
          + endpoint_public_access    = true
          + public_access_cidrs       = [
              + "0.0.0.0/0",
            ]
          + security_group_ids        = (known after apply)
          + subnet_ids                = [
              + "subnet-123456",
              + "subnet-234567",
            ]
          + vpc_id                    = (known after apply)
        }
    }

  # module.opsverse-eks-cluster.aws_iam_instance_profile.workers[0] will be created
  + resource "aws_iam_instance_profile" "workers" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = "opsverse-eks-cluster"
      + path        = "/"
      + role        = (known after apply)
      + tags_all    = (known after apply)
      + unique_id   = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_openid_connect_provider.oidc_provider[0] will be created
  + resource "aws_iam_openid_connect_provider" "oidc_provider" {
      + arn             = (known after apply)
      + client_id_list  = [
          + "sts.amazonaws.com",
        ]
      + id              = (known after apply)
      + tags            = {
          + "Name" = "opsverse-eks-cluster-eks-irsa"
        }
      + tags_all        = {
          + "Name" = "opsverse-eks-cluster-eks-irsa"
        }
      + thumbprint_list = [
          + "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",
        ]
      + url             = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_policy.cluster_elb_sl_role_creation[0] will be created
  + resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
      + arn         = (known after apply)
      + description = "Permissions for EKS to create AWSServiceRoleForElasticLoadBalancing service-linked role"
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = "opsverse-eks-cluster-elb-sl-role-creation"
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ec2:DescribeInternetGateways",
                          + "ec2:DescribeAddresses",
                          + "ec2:DescribeAccountAttributes",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role.cluster[0] will be created
  + resource "aws_iam_role" "cluster" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                      + Sid       = "EKSClusterAssumeRole"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = "opsverse-eks-cluster"
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.opsverse-eks-cluster.aws_iam_role.workers[0] will be created
  + resource "aws_iam_role" "workers" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = "EKSWorkerAssumeRole"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = "opsverse-eks-cluster"
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy[0] will be created
  + resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy[0] will be created
  + resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceControllerPolicy[0] will be created
  + resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSVPCResourceControllerPolicy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.cluster_elb_sl_role_creation[0] will be created
  + resource "aws_iam_role_policy_attachment" "cluster_elb_sl_role_creation" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly[0] will be created
  + resource "aws_iam_role_policy_attachment" "workers_AmazonEC2ContainerRegistryReadOnly" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.workers_AmazonEKSWorkerNodePolicy[0] will be created
  + resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_iam_role_policy_attachment.workers_AmazonEKS_CNI_Policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "workers_AmazonEKS_CNI_Policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
      + role       = (known after apply)
    }

  # module.opsverse-eks-cluster.aws_launch_configuration.workers[0] will be created
  + resource "aws_launch_configuration" "workers" {
      + arn                         = (known after apply)
      + associate_public_ip_address = false
      + ebs_optimized               = true
      + enable_monitoring           = true
      + iam_instance_profile        = (known after apply)
      + id                          = (known after apply)
      + image_id                    = "ami-0ca2b190717f1671e"
      + instance_type               = "m5a.xlarge"
      + key_name                    = "bastion"
      + name                        = (known after apply)
      + name_prefix                 = "opsverse-eks-cluster-0"
      + security_groups             = (known after apply)
      + user_data_base64            = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + no_device             = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = "enabled"
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = "optional"
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = false
          + iops                  = 0
          + throughput            = (known after apply)
          + volume_size           = 30
          + volume_type           = "gp2"
        }
    }

  # module.opsverse-eks-cluster.aws_security_group.cluster[0] will be created
  + resource "aws_security_group" "cluster" {
      + arn                    = (known after apply)
      + description            = "EKS cluster security group."
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "opsverse-eks-cluster"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "opsverse-eks-cluster-eks_cluster_sg"
        }
      + tags_all               = {
          + "Name" = "opsverse-eks-cluster-eks_cluster_sg"
        }
      + vpc_id                 = "vpc-123456"
    }

  # module.opsverse-eks-cluster.aws_security_group.workers[0] will be created
  + resource "aws_security_group" "workers" {
      + arn                    = (known after apply)
      + description            = "Security group for all nodes in the cluster."
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "opsverse-eks-cluster"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name"                                       = "opsverse-eks-cluster-eks_worker_sg"
          + "kubernetes.io/cluster/opsverse-eks-cluster" = "owned"
        }
      + tags_all               = {
          + "Name"                                       = "opsverse-eks-cluster-eks_worker_sg"
          + "kubernetes.io/cluster/opsverse-eks-cluster" = "owned"
        }
      + vpc_id                 = "vpc-123456"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.cluster_egress_internet[0] will be created
  + resource "aws_security_group_rule" "cluster_egress_internet" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Allow cluster egress access to the Internet."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.cluster_https_worker_ingress[0] will be created
  + resource "aws_security_group_rule" "cluster_https_worker_ingress" {
      + description              = "Allow pods to communicate with the EKS cluster API."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.workers_egress_internet[0] will be created
  + resource "aws_security_group_rule" "workers_egress_internet" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Allow nodes all egress to the Internet."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.workers_ingress_cluster[0] will be created
  + resource "aws_security_group_rule" "workers_ingress_cluster" {
      + description              = "Allow workers pods to receive communication from the cluster control plane."
      + from_port                = 1025
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "ingress"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.workers_ingress_cluster_https[0] will be created
  + resource "aws_security_group_rule" "workers_ingress_cluster_https" {
      + description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.opsverse-eks-cluster.aws_security_group_rule.workers_ingress_self[0] will be created
  + resource "aws_security_group_rule" "workers_ingress_self" {
      + description              = "Allow node to communicate with each other."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "ingress"
    }

  # module.opsverse-eks-cluster.kubernetes_config_map.aws_auth[0] will be created
  + resource "kubernetes_config_map" "aws_auth" {
      + data = (known after apply)
      + id   = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + labels           = {
              + "app.kubernetes.io/managed-by" = "Terraform"
              + "terraform.io/module"          = "terraform-aws-modules.eks.aws"
            }
          + name             = "aws-auth"
          + namespace        = "kube-system"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.opsverse-eks-cluster.local_file.kubeconfig[0] will be created
  + resource "local_file" "kubeconfig" {
      + content              = (known after apply)
      + directory_permission = "0755"
      + file_permission      = "0600"
      + filename             = "./kubeconfig_opsverse-eks-cluster"
      + id                   = (known after apply)
    }

  # module.s3_bucket_opsverse.aws_s3_bucket.bucket will be created
  + resource "aws_s3_bucket" "bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "opsverse-loki-yourname-stackname"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "Environment" = "production"
          + "Name"        = "opsverse-loki-yourname-stackname"
        }
      + tags_all                    = {
          + "Environment" = "production"
          + "Name"        = "opsverse-loki-yourname-stackname"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }

  # module.s3_bucket_opsverse.aws_s3_bucket_acl.bucket_acl will be created
  + resource "aws_s3_bucket_acl" "bucket_acl" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.s3_bucket_opsverse.aws_s3_bucket_public_access_block.public_access_policy will be created
  + resource "aws_s3_bucket_public_access_block" "public_access_policy" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

Plan: 31 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + loki_pod_role_arn = (known after apply)
```