### PR TITLE
Handling variables sent by the user in the agent config file

### DIFF
--- a/agents/host-amd64/setup.sh
+++ b/agents/host-amd64/setup.sh
@@ -108,8 +108,11 @@ function install_agent_config () {
   # Replace variables in agent config file
   HOSTNAME=$(hostname)
   B64PASS=$(echo -n "devopsnow:${PASS}" | base64)
+  METRICS_HOST=$(echo "${METRICS_HOST}" | sed -E 's~^https?://~~;s~/api/v1/write~~')
   sed -i "s/__METRICS_HOST__/${METRICS_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
+  LOGS_HOST=$(echo "${LOGS_HOST}" | sed -E 's~^https?://~~;s~/loki/api/v1/push~~')
   sed -i "s/__LOGS_HOST__/${LOGS_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
+  TRACES_COLLECTOR_HOST=$(echo "${TRACES_COLLECTOR_HOST}" | sed -E 's~^https?://~~;s~/api/v2/spans~~')
   sed -i "s/__TRACES_HOST__/${TRACES_COLLECTOR_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
   sed -i "s/__PASSWORD__/${PASS}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
   sed -i "s/__HOST__/${HOSTNAME}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}

--- a/agents/host-arm64/setup.sh
+++ b/agents/host-arm64/setup.sh
@@ -108,8 +108,11 @@ function install_agent_config () {
   # Replace variables in agent config file
   HOSTNAME=$(hostname)
   B64PASS=$(echo -n "devopsnow:${PASS}" | base64)
+  METRICS_HOST=$(echo "${METRICS_HOST}" | sed -E 's~^https?://~~;s~/api/v1/write~~')
   sed -i "s/__METRICS_HOST__/${METRICS_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
+  LOGS_HOST=$(echo "${LOGS_HOST}" | sed -E 's~^https?://~~;s~/loki/api/v1/push~~')
   sed -i "s/__LOGS_HOST__/${LOGS_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
+  TRACES_COLLECTOR_HOST=$(echo "${TRACES_COLLECTOR_HOST}" | sed -E 's~^https?://~~;s~/api/v2/spans~~')
   sed -i "s/__TRACES_HOST__/${TRACES_COLLECTOR_HOST}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
   sed -i "s/__PASSWORD__/${PASS}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}
   sed -i "s/__HOST__/${HOSTNAME}/g" ${OPSVERSE_AGENT_CONFIG_FULLPATH}


### PR DESCRIPTION
When the user inputs the whole URL variables when installing OpsVerse Agent. The flow breaks and the URL would be just
Metrics: `https://__METRICS_HOST__/api/v1/write`
Logs: `https://__LOGS_HOST__/loki/api/v1/push`

This PR makes sure that the above issue doesn't occur.

`[Edge cases used for testing](https://opsverse-mars.asia-south1.gcp.opsverse.cloud/explore?orgId=1&left=%7B%22datasource%22:%22metrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22metrics%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Binstance%3D%5C%22linux-amd64-1%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-5m%22,%22to%22:%22now%22%7D%7D)`:

Metrics:
`https://metrics-opsverse-mars.asia-south1.gcp.opsverse.cloud/api/v1/write`
`http://metrics-opsverse-mars.asia-south1.gcp.opsverse.cloud/api/v1/write`
`https://metrics-opsverse-mars.asia-south1.gcp.opsverse.cloud/api/v1/write`

Logs:
`https://logs-opsverse-mars.asia-south1.gcp.opsverse.cloud`
`http://logs-opsverse-mars.asia-south1.gcp.opsverse.cloud`
`logs-opsverse-mars.asia-south1.gcp.opsverse.cloud`
`logs-opsverse-mars.asia-south1.gcp.opsverse.cloud/loki/api/v1/push`
