### PR TITLE
[NOW-1927] Add extra label `node` in all installers

### DIFF
--- a/agents/host-amd64/agent-config.yaml
+++ b/agents/host-amd64/agent-config.yaml
@@ -20,7 +20,7 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
-              target_label: instance
+              target_label: node
               replacement: __HOST__
 
 logs:

--- a/agents/host-amd64/agent-config.yaml
+++ b/agents/host-amd64/agent-config.yaml
@@ -20,6 +20,10 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
+              target_label: instance
+              replacement: __HOST__
+            - source_labels: [__address__]
+              regex: '.*'
               target_label: node
               replacement: __HOST__
 

--- a/agents/host-arm64/agent-config.yaml
+++ b/agents/host-arm64/agent-config.yaml
@@ -20,7 +20,7 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
-              target_label: instance
+              target_label: node
               replacement: __HOST__
 
 logs:

--- a/agents/host-arm64/agent-config.yaml
+++ b/agents/host-arm64/agent-config.yaml
@@ -20,6 +20,10 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
+              target_label: instance
+              replacement: __HOST__
+            - source_labels: [__address__]
+              regex: '.*'
               target_label: node
               replacement: __HOST__
 

--- a/docker-compose/agent.yaml
+++ b/docker-compose/agent.yaml
@@ -18,7 +18,7 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
-              target_label: instance
+              target_label: node
               replacement: ${HOST}
         - job_name: cadvisor
           static_configs:
@@ -27,7 +27,7 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
-              target_label: instance
+              target_label: node
               replacement: ${HOST}
         # - job_name: mysqld-exporter
         #   static_configs:
@@ -36,7 +36,7 @@ metrics:
         #   relabel_configs:
         #     - source_labels: [__address__]
         #       regex: '.*'
-        #       target_label: instance
+        #       target_label: node
         #       replacement: ${HOST} 
 
 logs:

--- a/docker-compose/agent.yaml
+++ b/docker-compose/agent.yaml
@@ -18,6 +18,10 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
+              target_label: instance
+              replacement: ${HOST}
+            - source_labels: [__address__]
+              regex: '.*'
               target_label: node
               replacement: ${HOST}
         - job_name: cadvisor
@@ -27,6 +31,10 @@ metrics:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
+              target_label: instance
+              replacement: ${HOST}
+            - source_labels: [__address__]
+              regex: '.*'
               target_label: node
               replacement: ${HOST}
         # - job_name: mysqld-exporter
@@ -34,6 +42,10 @@ metrics:
         #   - targets:
         #     - 'mysqld-exporter:9104'
         #   relabel_configs:
+        #     - source_labels: [__address__]
+        #       regex: '.*'
+        #       target_label: instance
+        #       replacement: ${HOST} 
         #     - source_labels: [__address__]
         #       regex: '.*'
         #       target_label: node

--- a/opsverse-windows-agent-installation/agent-config.yaml
+++ b/opsverse-windows-agent-installation/agent-config.yaml
@@ -11,7 +11,7 @@ prometheus:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
-              target_label: instance
+              target_label: node
               replacement: __HOSTNAME__
       remote_write:
         - url: __METRICS_URL__

--- a/opsverse-windows-agent-installation/agent-config.yaml
+++ b/opsverse-windows-agent-installation/agent-config.yaml
@@ -11,6 +11,10 @@ prometheus:
           relabel_configs:
             - source_labels: [__address__]
               regex: '.*'
+              target_label: instance
+              replacement: __HOSTNAME__
+            - source_labels: [__address__]
+              regex: '.*'
               target_label: node
               replacement: __HOSTNAME__
       remote_write:


### PR DESCRIPTION
Tested this on Mars Grafana by creating instances:
Instance names: `node-label-sm-arm64`, `node-label-sm-amd64`, `node-label-windows`, `node-label-docker`
<img width="1677" alt="Screenshot 2023-12-06 at 14 41 20" src="https://github.com/OpsVerseIO/installers/assets/99061867/b7eaa8b5-913f-4dff-aae4-eaa95dd90137">
