### PR TITLE
[NOW-2350][MINOR] updating agent image to v0.40.3

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -3,5 +3,5 @@ OPSVERSE_METRICS_ENDPOINT=https://<observeNowMetricsHost>/api/v1/write
 OPSVERSE_LOGS_ENDPOINT=https://<observeNowLogsHost>/loki/api/v1/push
 OPSVERSE_USERNAME=devopsnow
 OPSVERSE_PASSWORD=<observeNowPassword>
-AGENT_VERSION=v0.28.0
+AGENT_VERSION=v0.40.3
 SCRAPE_INTERVAL=30s

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock
     entrypoint:
-      - /bin/agent
+      - /bin/grafana-agent
       - -config.file=/etc/agent-config/agent.yaml
       - -metrics.wal-directory=/tmp/agent/wal
       - -config.expand-env


### PR DESCRIPTION
Bumping up the grafana/agent image from `v0.28.0` to `v0.40.3` which is now inline with the version used in our observe-agent chart.

Testing - 
- Tested deploying the agent with this updated version in a VM. I was able to deploy the agent container successfully and push metrics and logs to grafana.